### PR TITLE
remove `tbd` in readme and add demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # log-density-plugin
 
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-online-brightgreen)](/docs)
 
 ## Table of Contents
@@ -41,6 +40,10 @@ The full documentation, including installation and usage instructions, can be fo
 
 - [Installation Guide](./docs/INSTALLATION.md)
 - [Usage Instructions](./docs/USAGE.md)
+
+Here is a short video that shows how to use the log assistant tool:
+
+[![demo-video](https://img.youtube.com/vi/2E8YjmcCWac/0.jpg)](https://www.youtube.com/watch?v=2E8YjmcCWac)
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Documentation for log-density-plugin (*name still TBD*)
+# Documentation for log-density-plugin
 
 [[Return]](../README.md)
 


### PR DESCRIPTION
- retirer coquille dans la documentation
- ajout du lien pour la vidéo de démonstration